### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -6,4 +6,4 @@
 ## Please, don't put extra comments in that file yet, keeping them is not supported yet.
 
 plugin.org.danilopianini.publish-on-central=0.4.1
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.