### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,6 @@ plugins {
     id("org.danilopianini.publish-on-central")
 }
 
-gitSemVer {
-    version = computeGitSemVer() // THIS IS MANDATORY, AND MUST BE LAST IN BLOCK
-}
-
 if (System.getenv("CI") == true.toString()) {
     signing {
         val signingKey: String? by project

--- a/versions.properties
+++ b/versions.properties
@@ -6,4 +6,4 @@
 ## Please, don't put extra comments in that file yet, keeping them is not supported yet.
 
 plugin.org.danilopianini.publish-on-central=0.5.0
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.